### PR TITLE
Broaden Info.plist search scope

### DIFF
--- a/.github/workflows/ios-build-testflight.yml
+++ b/.github/workflows/ios-build-testflight.yml
@@ -43,7 +43,7 @@ jobs:
         id: project_info
         run: |
           # Info.plistのパスを動的に検索
-          INFO_PLIST=$(find . -name "Info.plist" -path "*/BabySteps/*" | head -1)
+          INFO_PLIST=$(find . -name "Info.plist" | head -1)
           if [ -z "$INFO_PLIST" ]; then
             echo "Error: Info.plist not found"
             exit 1


### PR DESCRIPTION
Remove path restriction from `Info.plist` search to improve flexibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-ded2a190-4a96-4513-92f9-2042f9d436cc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ded2a190-4a96-4513-92f9-2042f9d436cc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

