### PR TITLE
Update Xcode and simulator versions in workflow

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -9,14 +9,14 @@ on:
 
 jobs:
   build-and-test:
-    runs-on: macos-15   # macOS 15 (Xcode 16.4が利用可能)
+    runs-on: macos-15   # macOS 15 (Xcode 16.3が利用可能)
     
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
       
-    - name: Select Xcode 16.4
-      run: sudo xcode-select -switch /Applications/Xcode_16.4.app
+    - name: Select Xcode 16.3
+      run: sudo xcode-select -switch /Applications/Xcode_16.3.app
       
     - name: Show available SDKs
       run: xcodebuild -showsdks
@@ -41,7 +41,7 @@ jobs:
         xcodebuild -project BabySteps.xcodeproj \
                    -scheme BabySteps \
                    -sdk iphonesimulator \
-                   -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.5' \
+                   -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.4' \
                    -derivedDataPath build \
                    -configuration Debug \
                    CODE_SIGN_STYLE=Automatic \
@@ -54,7 +54,7 @@ jobs:
         xcodebuild -project BabySteps.xcodeproj \
                    -scheme BabySteps \
                    -sdk iphonesimulator \
-                   -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.5' \
+                   -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.4' \
                    -derivedDataPath build \
                    -configuration Release \
                    CODE_SIGN_STYLE=Automatic \
@@ -68,7 +68,7 @@ jobs:
         xcodebuild -project BabySteps.xcodeproj \
                    -scheme BabySteps \
                    -sdk iphonesimulator \
-                   -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.5' \
+                   -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.4' \
                    -derivedDataPath build \
                    -configuration Debug \
                    CODE_SIGN_STYLE=Automatic \
@@ -80,7 +80,7 @@ jobs:
       run: |
         xcodebuild -project BabySteps.xcodeproj \
                    -scheme BabySteps \
-                   -sdk iphoneos18.5 \
+                   -sdk iphoneos18.4 \
                    -destination 'generic/platform=iOS' \
                    -derivedDataPath build \
                    -configuration Release \


### PR DESCRIPTION
Update GitHub Actions workflow to use Xcode 16.3 and iOS Simulator 18.4 to resolve build failures.

---
<a href="https://cursor.com/background-agent?bcId=bc-0fee8bca-dbd4-47eb-8b22-2cfef6c15c35">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0fee8bca-dbd4-47eb-8b22-2cfef6c15c35">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

