### PR TITLE
Set app uses non-exempt encryption to false

### DIFF
--- a/Sources/Info.plist
+++ b/Sources/Info.plist
@@ -44,5 +44,7 @@
         <string>UIInterfaceOrientationLandscapeLeft</string>
         <string>UIInterfaceOrientationLandscapeRight</string>
     </array>
+    <key>ITSAppUsesNonExemptEncryption</key>
+    <false/>
 </dict>
 </plist>


### PR DESCRIPTION
Add `ITSAppUsesNonExemptEncryption` key with `false` value to Info.plist to declare non-use of non-exempt encryption.

---
<a href="https://cursor.com/background-agent?bcId=bc-220a3484-268f-4faa-b1c4-72acc4ffe781">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-220a3484-268f-4faa-b1c4-72acc4ffe781">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

