### PR TITLE
Visualize daily github commits in second tab

### DIFF
--- a/Sources/Models/Activity.swift
+++ b/Sources/Models/Activity.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+struct DailyActivity {
+    let date: Date
+    let commitCount: Int
+    let activityLevel: ActivityLevel
+}

--- a/Sources/Models/ActivityLevel.swift
+++ b/Sources/Models/ActivityLevel.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+
+enum ActivityLevel: Int, CaseIterable {
+    case none = 0      // 0件
+    case low = 1       // 1-3件
+    case medium = 2    // 4-6件
+    case high = 3      // 7-9件
+    case veryHigh = 4  // 10件以上
+    
+    var color: Color {
+        switch self {
+        case .none: return Color(hex: "#ebedf0")
+        case .low: return Color(hex: "#a8e6b8")      // より明るい緑
+        case .medium: return Color(hex: "#4cd46e")    // より明るい緑
+        case .high: return Color(hex: "#3bb85a")      // より明るい緑
+        case .veryHigh: return Color(hex: "#2a8a47")  // より明るい緑
+        }
+    }
+}
+
+// Color拡張でhexカラーをサポート
+extension Color {
+    init(hex: String) {
+        let hex = hex.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
+        var int: UInt64 = 0
+        Scanner(string: hex).scanHexInt64(&int)
+        let a, r, g, b: UInt64
+        switch hex.count {
+        case 3: // RGB (12-bit)
+            (a, r, g, b) = (255, (int >> 8) * 17, (int >> 4 & 0xF) * 17, (int & 0xF) * 17)
+        case 6: // RGB (24-bit)
+            (a, r, g, b) = (255, int >> 16, int >> 8 & 0xFF, int & 0xFF)
+        case 8: // ARGB (32-bit)
+            (a, r, g, b) = (int >> 24, int >> 16 & 0xFF, int >> 8 & 0xFF, int & 0xFF)
+        default:
+            (a, r, g, b) = (1, 1, 1, 0)
+        }
+
+        self.init(
+            .sRGB,
+            red: Double(r) / 255,
+            green: Double(g) / 255,
+            blue:  Double(b) / 255,
+            opacity: Double(a) / 255
+        )
+    }
+}

--- a/Sources/Models/Task.swift
+++ b/Sources/Models/Task.swift
@@ -52,16 +52,23 @@ final class TaskStep {
     var isCompleted: Bool
     var order: Int
     var task: Task?
+    var completedAt: Date?
     
     init(title: String, order: Int) {
         self.id = UUID()
         self.title = title
         self.isCompleted = false
         self.order = order
+        self.completedAt = nil
     }
     
     // ステップの完了状態を切り替え
     func toggleCompletion() {
         isCompleted.toggle()
+        if isCompleted {
+            completedAt = Date()
+        } else {
+            completedAt = nil
+        }
     }
 }

--- a/Sources/ViewModels/TaskViewModel.swift
+++ b/Sources/ViewModels/TaskViewModel.swift
@@ -4,7 +4,7 @@ import SwiftUI
 
 @Observable
 class TaskViewModel {
-    private var modelContext: ModelContext
+    let modelContext: ModelContext
     
     init(modelContext: ModelContext) {
         self.modelContext = modelContext

--- a/Sources/Views/TaskListView.swift
+++ b/Sources/Views/TaskListView.swift
@@ -42,6 +42,9 @@ struct TaskListView: View {
             .onAppear {
                 // ModelContextを注入
                 viewModel = TaskViewModel(modelContext: modelContext)
+                
+                // 既存の完了済みステップにcompletedAtを設定
+                initializeCompletedSteps()
             }
         }
     }
@@ -179,6 +182,18 @@ struct TaskListView: View {
         guard !tasks.isEmpty else { return 0.0 }
         let totalProgress = tasks.reduce(0.0) { $0 + $1.progress }
         return totalProgress / Double(tasks.count)
+    }
+    
+    // 既存の完了済みステップにcompletedAtを設定
+    private func initializeCompletedSteps() {
+        for task in tasks {
+            for step in task.steps {
+                if step.isCompleted && step.completedAt == nil {
+                    step.completedAt = Date()
+                }
+            }
+        }
+        try? viewModel.modelContext.save()
     }
 }
 


### PR DESCRIPTION
Adds `completedAt` to `TaskStep` and introduces `DailyActivity` and `ActivityLevel` models to support the new activity tracking feature.

This PR represents Phase 1 of implementing the 'GitHub grass' like activity view, focusing on establishing the necessary data structures and backfilling existing data.

---
<a href="https://cursor.com/background-agent?bcId=bc-bec0eb9e-21ac-4e07-ac0c-877ff80d71fc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bec0eb9e-21ac-4e07-ac0c-877ff80d71fc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

