### PR TITLE
Manage task check-ins with multiple checkboxes

### DIFF
--- a/Sources/Models/Task.swift
+++ b/Sources/Models/Task.swift
@@ -47,30 +47,4 @@ final class Task {
     }
 }
 
-@Model
-final class TaskStep {
-    var id: UUID
-    var title: String
-    var isCompleted: Bool
-    var order: Int
-    var task: Task?
-    var completedAt: Date?
-    
-    init(title: String, order: Int) {
-        self.id = UUID()
-        self.title = title
-        self.isCompleted = false
-        self.order = order
-        self.completedAt = nil
-    }
-    
-    // ステップの完了状態を切り替え
-    func toggleCompletion() {
-        isCompleted.toggle()
-        if isCompleted {
-            completedAt = Date()
-        } else {
-            completedAt = nil
-        }
-    }
-}
+

--- a/Sources/Models/TaskStep.swift
+++ b/Sources/Models/TaskStep.swift
@@ -1,0 +1,30 @@
+import Foundation
+import SwiftData
+
+@Model
+final class TaskStep {
+    var id: UUID
+    var title: String
+    var isCompleted: Bool
+    var order: Int
+    var task: Task?
+    var completedAt: Date?
+    
+    init(title: String, order: Int) {
+        self.id = UUID()
+        self.title = title
+        self.isCompleted = false
+        self.order = order
+        self.completedAt = nil
+    }
+    
+    // ステップの完了状態を切り替え
+    func toggleCompletion() {
+        isCompleted.toggle()
+        if isCompleted {
+            completedAt = Date()
+        } else {
+            completedAt = nil
+        }
+    }
+}


### PR DESCRIPTION
Move `TaskStep` class from `Task.swift` to `TaskStep.swift` to prepare for its refactoring into a task check-in model.

This move isolates the `TaskStep` model, making it easier to modify its structure to function as a simple check-in counter for tasks, while retaining the `TaskStep` name to support future functionality that includes both simple check-ins and full task decomposition.

---
<a href="https://cursor.com/background-agent?bcId=bc-843957bf-101c-43d6-97db-59d48cff7f06">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-843957bf-101c-43d6-97db-59d48cff7f06">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

