### PR TITLE
Remove step numbers from task checkboxes

### DIFF
--- a/Sources/Views/TaskListView.swift
+++ b/Sources/Views/TaskListView.swift
@@ -260,13 +260,10 @@ struct TaskRowView: View {
                             }) {
                                 Image(systemName: step.isCompleted ? "checkmark.square.fill" : "square")
                                     .foregroundColor(step.isCompleted ? .green : .gray)
+                                    .font(.title2)
                             }
                             .buttonStyle(PlainButtonStyle())
                             .disabled(viewModel == nil)
-                            
-                            Text("ステップ\(step.order + 1)")
-                                .strikethrough(step.isCompleted)
-                                .foregroundColor(step.isCompleted ? .secondary : .primary)
                             
                             Spacer()
                         }


### PR DESCRIPTION
Remove "ステップN" text from task steps and enlarge checkboxes to display only checkboxes as requested.

---
<a href="https://cursor.com/background-agent?bcId=bc-febc7b34-f0a6-460b-a457-4bf9b96481ff">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-febc7b34-f0a6-460b-a457-4bf9b96481ff">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

