### PR TITLE
Automate TestFlight release on main merge

### DIFF
--- a/.github/workflows/ios-build-testflight.yml
+++ b/.github/workflows/ios-build-testflight.yml
@@ -2,6 +2,18 @@ name: iOS Build → TestFlight (Auto-Sign on Export)
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - '.gitignore'
+      - '.markdownlint.json'
+      - '.swift-format'
+      - 'screenshot-config.json'
+      - 'GITHUB_ACTIONS_SETUP.md'
+      - 'SCREENSHOT_GENERATION.md'
 
 jobs:
   release:


### PR DESCRIPTION
Add `push` trigger to the TestFlight release workflow for `main` branch, automating releases on merge while ignoring non-code changes.

---
<a href="https://cursor.com/background-agent?bcId=bc-7c6cb418-d467-4073-bb31-a9e408923f1b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7c6cb418-d467-4073-bb31-a9e408923f1b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

