### PR TITLE
Prepare for ios26 compatibility

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -2,8 +2,8 @@ name: BabySteps
 options:
   bundleIdPrefix: com.yu1Ro5
   deploymentTarget:
-    iOS: "18.0"
-  xcodeVersion: "16.4"
+    iOS: "26.0"
+  xcodeVersion: "26.0"
   generateEmptyDirectories: true
   groupSortPosition: top
 
@@ -17,7 +17,7 @@ targets:
   BabySteps:
     type: application
     platform: iOS
-    deploymentTarget: "18.0"
+    deploymentTarget: "26.0"
     sources:
       - path: Sources
         type: group
@@ -38,7 +38,7 @@ targets:
   BabyStepsTests:
     type: bundle.unit-test
     platform: iOS
-    deploymentTarget: "18.0"
+    deploymentTarget: "26.0"
     sources:
       - path: Tests
         type: group


### PR DESCRIPTION
Update iOS deployment target and Xcode version to 26.0 to support iOS 26.

This change sets the minimum supported iOS version to 26.0 and requires Xcode 26 for development, enabling the use of new iOS 26 APIs and features.

---
<a href="https://cursor.com/background-agent?bcId=bc-12d4f4c4-203a-415b-bb81-96aec13b4eff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-12d4f4c4-203a-415b-bb81-96aec13b4eff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

