### PR TITLE
Update development environment to version 26

### DIFF
--- a/.github/workflows/format-patch.yml
+++ b/.github/workflows/format-patch.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   format-patch:
     name: format-patch
-    runs-on: macos-latest
+    runs-on: macos-26
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/generate-screenshots.yml
+++ b/.github/workflows/generate-screenshots.yml
@@ -9,24 +9,21 @@ on:
 
 jobs:
   screenshots:
-    runs-on: macos-15
+    runs-on: macos-26
     timeout-minutes: 30
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Select Xcode 16.4
+      - name: Select Xcode 26
         run: |
-          # Xcode 16.4が利用可能かチェック
-          if [ -d "/Applications/Xcode_16.4.app" ]; then
-            sudo xcode-select -switch /Applications/Xcode_16.4.app
-            echo "✅ Xcode 16.4 selected"
-          elif [ -d "/Applications/Xcode_16.3.app" ]; then
-            sudo xcode-select -switch /Applications/Xcode_16.3.app
-            echo "⚠️ Xcode 16.3 selected (16.4 not available)"
+          # Xcode 26が利用可能かチェック
+          if [ -d "/Applications/Xcode_26.app" ]; then
+            sudo xcode-select -switch /Applications/Xcode_26.app
+            echo "✅ Xcode 26 selected"
           else
-            echo "❌ Xcode 16.4 or 16.3 not found"
+            echo "❌ Xcode 26 not found"
             exit 1
           fi
 
@@ -52,8 +49,8 @@ jobs:
           echo "=== Available iOS Runtimes ==="
           xcrun simctl list runtimes | grep "iOS" || echo "No iOS runtimes found"
 
-          # iOS 18.5を固定で使用
-          export IOS_VERSION="18.5"
+          # iOS 26.0を固定で使用
+          export IOS_VERSION="26.0"
           echo "Using iOS version: $IOS_VERSION"
 
       - name: Setup simulators
@@ -62,10 +59,10 @@ jobs:
 
           # 利用可能なシミュレータを確認
           echo "=== Available iPhone Simulators ==="
-          xcrun simctl list devices available | grep "iPhone" | grep "18.5" || echo "No iPhone simulators found for iOS 18.5"
+          xcrun simctl list devices available | grep "iPhone" | grep "26.0" || echo "No iPhone simulators found for iOS 26.0"
 
           echo "=== Available iPad Simulators ==="
-          xcrun simctl list devices available | grep "iPad" | grep "18.5" || echo "No iPad simulators found for iOS 18.5"
+          xcrun simctl list devices available | grep "iPad" | grep "26.0" || echo "No iPad simulators found for iOS 26.0"
 
       - name: Build app for iPhone
         run: |
@@ -73,7 +70,7 @@ jobs:
           xcodebuild -project BabySteps.xcodeproj \
             -scheme BabySteps \
             -sdk iphonesimulator \
-            -destination 'platform=iOS Simulator,name=iPhone 16 Pro Max,OS=18.5' \
+            -destination 'platform=iOS Simulator,name=iPhone 16 Pro Max,OS=26.0' \
             -derivedDataPath build \
             -configuration Debug \
             CODE_SIGN_STYLE=Automatic \
@@ -116,7 +113,7 @@ jobs:
           xcodebuild -project BabySteps.xcodeproj \
             -scheme BabySteps \
             -sdk iphonesimulator \
-            -destination 'platform=iOS Simulator,name=iPad Pro 13-inch (M4),OS=18.5' \
+            -destination 'platform=iOS Simulator,name=iPad Pro 13-inch (M4),OS=26.0' \
             -derivedDataPath build \
             -configuration Debug \
             CODE_SIGN_STYLE=Automatic \

--- a/.github/workflows/ios-build-testflight.yml
+++ b/.github/workflows/ios-build-testflight.yml
@@ -17,15 +17,15 @@ on:
 
 jobs:
   release:
-    runs-on: macos-15   # macOS 15 (Xcode 16.1が利用可能)
+    runs-on: macos-26   # macOS 26 (Xcode 26が利用可能)
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      # Xcode 16.4を明示的に選択
-      - name: Select Xcode 16.4
-        run: sudo xcode-select -switch /Applications/Xcode_16.4.app
+      # Xcode 26を明示的に選択
+      - name: Select Xcode 26
+        run: sudo xcode-select -switch /Applications/Xcode_26.app
 
       # 利用可能なSDKを表示
       - name: Show available SDKs
@@ -44,7 +44,7 @@ jobs:
           xcodebuild archive \
             -project BabySteps.xcodeproj \
             -scheme BabySteps \
-            -sdk iphoneos18.5 \
+            -sdk iphoneos26.0 \
             -configuration Release \
             -archivePath BabySteps.xcarchive \
             -destination "generic/platform=iOS" \

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -9,14 +9,14 @@ on:
 
 jobs:
   build-and-test:
-    runs-on: macos-15   # macOS 15 (Xcode 16.3が利用可能)
+    runs-on: macos-26   # macOS 26 (Xcode 26が利用可能)
 
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
 
-    - name: Select Xcode 16.3
-      run: sudo xcode-select -switch /Applications/Xcode_16.3.app
+    - name: Select Xcode 26
+      run: sudo xcode-select -switch /Applications/Xcode_26.app
 
     - name: Show available SDKs
       run: xcodebuild -showsdks
@@ -41,7 +41,7 @@ jobs:
         xcodebuild -project BabySteps.xcodeproj \
                    -scheme BabySteps \
                    -sdk iphonesimulator \
-                   -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.4' \
+                   -destination 'platform=iOS Simulator,name=iPhone 16,OS=26.0' \
                    -derivedDataPath build \
                    -configuration Debug \
                    CODE_SIGN_STYLE=Automatic \
@@ -54,7 +54,7 @@ jobs:
         xcodebuild -project BabySteps.xcodeproj \
                    -scheme BabySteps \
                    -sdk iphonesimulator \
-                   -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.4' \
+                   -destination 'platform=iOS Simulator,name=iPhone 16,OS=26.0' \
                    -derivedDataPath build \
                    -configuration Release \
                    CODE_SIGN_STYLE=Automatic \
@@ -68,7 +68,7 @@ jobs:
         xcodebuild -project BabySteps.xcodeproj \
                    -scheme BabySteps \
                    -sdk iphonesimulator \
-                   -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.4' \
+                   -destination 'platform=iOS Simulator,name=iPhone 16,OS=26.0' \
                    -derivedDataPath build \
                    -configuration Debug \
                    CODE_SIGN_STYLE=Automatic \
@@ -80,7 +80,7 @@ jobs:
       run: |
         xcodebuild -project BabySteps.xcodeproj \
                    -scheme BabySteps \
-                   -sdk iphoneos18.4 \
+                   -sdk iphoneos26.0 \
                    -destination 'generic/platform=iOS' \
                    -derivedDataPath build \
                    -configuration Release \

--- a/project.yml
+++ b/project.yml
@@ -2,8 +2,8 @@ name: BabySteps
 options:
   bundleIdPrefix: com.yu1Ro5
   deploymentTarget:
-    iOS: "18.0"
-  xcodeVersion: "16.4"
+    iOS: "26.0"
+  xcodeVersion: "26"
   generateEmptyDirectories: true
   groupSortPosition: top
 
@@ -17,7 +17,7 @@ targets:
   BabySteps:
     type: application
     platform: iOS
-    deploymentTarget: "18.0"
+    deploymentTarget: "26.0"
     sources:
       - path: Sources
         type: group
@@ -38,7 +38,7 @@ targets:
   BabyStepsTests:
     type: bundle.unit-test
     platform: iOS
-    deploymentTarget: "18.0"
+    deploymentTarget: "26.0"
     sources:
       - path: Tests
         type: group


### PR DESCRIPTION
Update development environment to support iOS 26 as minimum version and use Xcode 26 with macOS 26 for CI.

---
<a href="https://cursor.com/background-agent?bcId=bc-7c55a7f2-4b07-4c77-9226-87c7a129ad53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7c55a7f2-4b07-4c77-9226-87c7a129ad53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

